### PR TITLE
Removed enableImplicitConversion

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -12,10 +12,7 @@ async function bootstrap (): Promise<void> {
     new ValidationPipe({
       whitelist: true,
       forbidNonWhitelisted: true,
-      transform: true,
-      transformOptions: {
-        enableImplicitConversion: true
-      }
+      transform: true
     })
   )
   app.setGlobalPrefix('api', {


### PR DESCRIPTION
enableImplicitConversion

Zorgt ervoor dat de values automatisch geconverteerd worden. Dit zorgt ervoor dat de class validators niet meer werken zoals verwacht

```
@IsBoolean
value: boolean

value = 'false' // gaat true terug geven op de validator
```