### PR TITLE
Feature: use url instead of port/host

### DIFF
--- a/src/config/env/configuration.ts
+++ b/src/config/env/configuration.ts
@@ -1,6 +1,5 @@
 import { type EnvConfiguration } from './env-configuration.type.js'
 
 export default (): EnvConfiguration => ({
-  redisHost: process.env.REDIS_HOST ?? 'localhost',
-  redisPort: parseInt(process.env.REDIS_PORT ?? '6379', 10)
+  redisUrl: process.env.REDIS_URL ?? 'redis://localhost:6379'
 })

--- a/src/config/env/env-configuration.type.ts
+++ b/src/config/env/env-configuration.type.ts
@@ -1,4 +1,3 @@
 export interface EnvConfiguration {
-  redisHost: string
-  redisPort: number
+  redisUrl: string
 }

--- a/src/utils/cache/cache.module.ts
+++ b/src/utils/cache/cache.module.ts
@@ -13,10 +13,7 @@ import { RedisCacheService } from './cache.js'
     imports: [ConfigModule],
     useFactory: async (configService: ConfigService) => ({
       store: await redisStore({
-        socket: {
-          host: configService.get('REDIS_HOST'),
-          port: configService.get('REDIS_PORT')
-        }
+        url: configService.get('REDIS_URL')
       })
     }),
     inject: [ConfigService]


### PR DESCRIPTION
Simplifies setup for SysOps (use one env variable instead of 2)