### PR TITLE
Bugfix: Fixed query_by builder and offset.

### DIFF
--- a/src/modules/typesense/builder/search-params.builder.ts
+++ b/src/modules/typesense/builder/search-params.builder.ts
@@ -4,7 +4,7 @@ import { type SortDirection } from '../../../utils/query/sort-direction.enum.js'
 import { FilterOptions } from '../enums/typesense-filter-options.enum.js'
 
 export const DEFAULT_LIMIT = 10
-export const DEFAULT_OFFSET = 1
+export const DEFAULT_OFFSET = 0
 
 export class TypesenseSearchParamsBuilder<Collection extends TypesenseCollection> {
   private readonly filters: string[] = []
@@ -75,7 +75,9 @@ export class TypesenseSearchParamsBuilder<Collection extends TypesenseCollection
     if (this.queries.length > 0) {
       queryBy = this.queries.join(',')
     } else {
-      queryBy = this.collection.searchableFields.join(',')
+      queryBy = this.collection.searchableFields
+        .map(field => field.name)
+        .join(',')
     }
 
     const searchParams: SearchParams = {

--- a/src/modules/typesense/services/typesense-query.service.ts
+++ b/src/modules/typesense/services/typesense-query.service.ts
@@ -4,6 +4,7 @@ import { type SearchParams } from 'typesense/lib/Typesense/Documents.js'
 import { type MultiSearchResult, type TypesenseCollectionName } from '../enums/typesense-collection-index.enum.js'
 import { TypesenseClient } from '../clients/typesense.client.js'
 import { UserTypesenseCollection, type UserSearchSchema } from '../collections/user.collections.js'
+import { DEFAULT_LIMIT } from '../builder/search-params.builder.js'
 
 @Injectable()
 export class TypesenseQueryService {
@@ -45,8 +46,8 @@ export class TypesenseQueryService {
           items: result.hits?.map(hit => hit.document) as UserSearchSchema[] ?? [],
           meta: {
             total: result.found,
-            offset: result.page - 1,
-            limit: result.request_params.per_page ?? 0
+            offset: (result.page - 1) * (result.request_params.per_page ?? 0),
+            limit: result.request_params.per_page ?? DEFAULT_LIMIT
           }
         }
       }


### PR DESCRIPTION
- `searchableFields.join(',')` result in `[Object object]` since it joined the field itself. We want to join the name of the field (`firstName`, `lastName`)
- Something was wrong with the offset where it resulted in `NaN` for empty limit and offset query parameters. Might need to be validated by someone else aswell.