### PR TITLE
Rename validate password to verify password

### DIFF
--- a/src/modules/users/services/user.service.ts
+++ b/src/modules/users/services/user.service.ts
@@ -3,7 +3,7 @@ import { type User } from '../entities/user.entity.js'
 import { UserRepository } from '../repositories/user.repository.js'
 import { UserTypesenseRepository } from '../repositories/user-typesense.repository.js'
 import { RoleRepository } from '../../roles/repositories/role.repository.js'
-import { validatePassword } from '../../../utils/helpers/hash.helper.js'
+import { verifyPassword } from '../../../utils/helpers/hash.helper.js'
 
 @Injectable()
 export class UserService {
@@ -30,7 +30,7 @@ export class UserService {
   async verify (email: string, password: string): Promise<User | false> {
     try {
       const user = await this.findOneByEmail(email)
-      await validatePassword(password, user.password)
+      await verifyPassword(password, user.password)
 
       return user
     } catch (e) {

--- a/src/modules/users/use-cases/change-password/change-password.use-case.ts
+++ b/src/modules/users/use-cases/change-password/change-password.use-case.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common'
 import { UserRepository } from '../../repositories/user.repository.js'
 import { type User } from '../../entities/user.entity.js'
-import { createHash, validatePassword } from '../../../../utils/helpers/hash.helper.js'
+import { createHash, verifyPassword } from '../../../../utils/helpers/hash.helper.js'
 import { type ChangePasswordCommand } from './change-password.command.js'
 
 @Injectable()
@@ -15,7 +15,7 @@ export class ChangePasswordUseCase {
     changePasswordRequest: ChangePasswordCommand
   ): Promise<User> {
     const user = await this.userRepository.findOneByOrFail({ uuid: forUserUuid })
-    await validatePassword(changePasswordRequest.oldPassword, user.password)
+    await verifyPassword(changePasswordRequest.oldPassword, user.password)
     const newPassword = await createHash(changePasswordRequest.newPassword)
     await this.userRepository.update({ uuid: forUserUuid.toString() }, { password: newPassword })
     return user

--- a/src/utils/helpers/hash.helper.ts
+++ b/src/utils/helpers/hash.helper.ts
@@ -5,8 +5,8 @@ export async function createHash (value: string): Promise<string> {
   return await bcrypt.hash(value, 10)
 }
 
-export async function validatePassword (oldPassword: string, newPassword: string): Promise<void> {
-  const match = await bcrypt.compare(oldPassword, newPassword)
+export async function verifyPassword (password: string, hashedPassword: string): Promise<void> {
+  const match = await bcrypt.compare(password, hashedPassword)
   if (!match) {
     throw new KnownError('invalid_credentials')
   }


### PR DESCRIPTION
Validate is not the same as verifying. (e.g. the password has at least 6 characters = validate)
Reveal the intention in the parameters names.