### PR TITLE
Feature/exceptions

### DIFF
--- a/src/modules/exceptions/exception.filter.ts
+++ b/src/modules/exceptions/exception.filter.ts
@@ -68,7 +68,7 @@ export class CustomerExceptionFilter implements ExceptionFilter {
         code: exception.code,
         detail: exception.detail,
         status: exception.status,
-        meta: exception.meta
+        meta: Object.assign({}, exception.meta)
       }]
     })
   }

--- a/src/modules/validation/convert-validation-errors.ts
+++ b/src/modules/validation/convert-validation-errors.ts
@@ -2,6 +2,7 @@ import type { ValidationError } from 'class-validator'
 import { plainToInstance } from 'class-transformer'
 import { HttpStatus } from '@nestjs/common'
 import { JsonApiErrorContent, JsonApiError } from '../exceptions/types/json-api-error.type.js'
+import { camelToSnakeCase } from '../../utils/helpers/camel-to-snake-case.js'
 
 function convertValidationError (errors: ValidationError[], path = '$'): JsonApiErrorContent[] {
   const convertedErrors: JsonApiErrorContent[] = []
@@ -13,9 +14,11 @@ function convertValidationError (errors: ValidationError[], path = '$'): JsonApi
 
     if (error.children === undefined || error.children.length === 0) {
       if (error.constraints !== undefined) {
+        const validationConstraintName = Object.keys(error.constraints)[0]
+
         convertedErrors.push({
           source: { pointer: jsonpath },
-          code: 'validation_error',
+          code: 'validation_error_' + camelToSnakeCase(validationConstraintName),
           detail: Object.values(error.constraints)[0]
         })
       }

--- a/src/utils/helpers/camel-to-snake-case.ts
+++ b/src/utils/helpers/camel-to-snake-case.ts
@@ -1,0 +1,3 @@
+export function camelToSnakeCase (word: string): string {
+  return word.replace(/([A-Z])/g, letter => `_${letter.toLowerCase()}`)
+}


### PR DESCRIPTION
Additions:
1. Added `Object.assign({}, exception.meta)`
  - This was needed when the ApiError included a "meta" class with a constructor. When this is the case, the constructor will be called with undefined properties.
2. Include constraint name in validation error code