### PR TITLE
Link aliasName and collectionName before importing to typesense

### DIFF
--- a/src/modules/typesense/services/typesense-initialization.service.ts
+++ b/src/modules/typesense/services/typesense-initialization.service.ts
@@ -79,8 +79,8 @@ export class TypesenseInitializationService {
     if (fresh || !exists) {
       const collection = await this.createCollection(createCollection)
 
-      await this.typesenseCollectionService.importToTypesense(aliasName)
       await this.linkAlias(aliasName, collection.name)
+      await this.typesenseCollectionService.importToTypesense(aliasName)
       await this.deleteUnusedCollections()
     }
   }


### PR DESCRIPTION
While implementing typesense, I have encountered that the implementation of `migrateCollection` is not working as it should. I believe the `linkAlias` method should happen before the `importToTypesense`.  The link from the alias name to the new collection must happen before the new documents are added. Previously, `linkAlias` was executed before the import, causing the documents to be added to the old collection that was linked to the alias. Afterwards, the alias was linked to the newly created collection. Finally, the previously linked collection was deleted, along with all the newly added documents.